### PR TITLE
upgrade tsconfig's es target to es2022

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2022",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
This change is necessary for using async/await syntax. I *believe* that will make the code cleaner for the OpenAI integration, but figured there are few drawbacks to upgrading to es2022 so might as well do it now. Then everyone can start working in that syntax asap.

This change probably won't affect anything we already have. It doesn't affect anything currently in `main`.