### PR TITLE
Add quick settings

### DIFF
--- a/lib/components/QuickSettings.tsx
+++ b/lib/components/QuickSettings.tsx
@@ -1,0 +1,148 @@
+import ScoreCategoriesSettings from "@/lib/models/ScoreCategoriesSettings";
+import ScoreCategory from "@/lib/models/ScoreCategory";
+import ScoreCategorySettings from "@/lib/models/ScoreCategorySettings";
+import SummaryScoreMode from "@/lib/models/SummaryScoreMode";
+import styles from "@/styles/components/QuickSettings.module.scss";
+import { faCircleQuestion, faCog, faRotate } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+type ToggleSliderProps = {
+  category: ScoreCategory;
+  label: string;
+  min: number;
+  max: number;
+  step: number;
+  settings: ScoreCategorySettings;
+  onChange: (category: ScoreCategory, enabled: boolean, value: number) => void;
+} & typeof defaultToggleSliderProps;
+
+const defaultToggleSliderProps = {
+  min: 0,
+  max: 1,
+  step: 0.01,
+};
+
+function ToggleSlider(props: ToggleSliderProps): JSX.Element {
+  function onClick(): void {
+    props.onChange(props.category, !props.settings.enabled, props.settings.weight);
+  }
+
+  function onSliderChange(event: React.ChangeEvent<HTMLInputElement>): void {
+    event.preventDefault();
+    props.onChange(props.category, props.settings.enabled, Number(event.currentTarget.value));
+  }
+
+  return (
+    <div
+      // Add disabled class if disabled
+      className={
+        styles.toggleSlider + (props.settings.enabled ? "" : ` ${styles["toggleSlider--disabled"]}`)
+      }
+      onClick={onClick}
+      onMouseDown={event => {
+        // Disable text selection on double click
+        if (event.detail > 1) event.preventDefault();
+      }}
+    >
+      <span>{props.label}</span>
+
+      <input
+        type="range"
+        min={props.min}
+        max={props.max}
+        step={props.step}
+        value={props.settings.weight}
+        onChange={onSliderChange}
+        onClick={event => {
+          // Prevent click event from bubbling up to parent
+          event.stopPropagation();
+        }}
+      />
+    </div>
+  );
+}
+ToggleSlider.defaultProps = defaultToggleSliderProps;
+
+interface QuickSettingsProps {
+  summaryScoreMode: SummaryScoreMode;
+  handleSummaryScoreModeChange: (summaryScoreMode: SummaryScoreMode) => void;
+  scoreCategoriesSettings: ScoreCategoriesSettings;
+  handleScoreCategoriesSettingsChange: (scoreCategoriesSettings: ScoreCategoriesSettings) => void;
+  handleReset: () => void;
+}
+
+export default function QuickSettings(props: QuickSettingsProps): JSX.Element {
+  function onToggleClick(event: React.ChangeEvent<HTMLInputElement>): void {
+    const summaryScoreMode = event.currentTarget.checked
+      ? SummaryScoreMode.weighted
+      : SummaryScoreMode.highest;
+    props.handleSummaryScoreModeChange(summaryScoreMode);
+  }
+
+  function onSliderChange(category: ScoreCategory, enabled: boolean, weight: number): void {
+    props.handleScoreCategoriesSettingsChange({
+      ...props.scoreCategoriesSettings,
+      ...{ [category]: { enabled: enabled, weight: weight } },
+    });
+  }
+
+  return (
+    <div className={styles.mainContainer}>
+      {/* Heading */}
+      <h2>
+        <FontAwesomeIcon icon={faCog} /> Settings <FontAwesomeIcon icon={faCircleQuestion} />
+      </h2>
+
+      {/* Toggle for summary score mode */}
+      <div>
+        <span>Highest</span>
+
+        {/* #TODO: Animated toggle */}
+        <input
+          type="checkbox"
+          value={props.summaryScoreMode === SummaryScoreMode.weighted ? "on" : "off"}
+          onChange={onToggleClick}
+        />
+
+        <span>Weighted</span>
+      </div>
+
+      <div style={{ height: 15 }}></div>
+
+      {/* Toggles and sliders for each score category */}
+      <div className={styles.toggleSliders}>
+        <ToggleSlider
+          label="Toxic"
+          category={ScoreCategory.toxic}
+          settings={props.scoreCategoriesSettings[ScoreCategory.toxic]}
+          onChange={onSliderChange}
+        />
+        <ToggleSlider
+          label="Profane"
+          category={ScoreCategory.profane}
+          settings={props.scoreCategoriesSettings[ScoreCategory.profane]}
+          onChange={onSliderChange}
+        />
+        <ToggleSlider
+          label="Threat"
+          category={ScoreCategory.threat}
+          settings={props.scoreCategoriesSettings[ScoreCategory.threat]}
+          onChange={onSliderChange}
+        />
+        <ToggleSlider
+          label="Insult"
+          category={ScoreCategory.insult}
+          settings={props.scoreCategoriesSettings[ScoreCategory.insult]}
+          onChange={onSliderChange}
+        />
+      </div>
+
+      <div style={{ height: 25 }}></div>
+
+      {/* Reset button */}
+      <button onClick={props.handleReset}>
+        <FontAwesomeIcon icon={faRotate} /> Reset
+      </button>
+    </div>
+  );
+}

--- a/lib/models/ScoreCategoriesSettings.ts
+++ b/lib/models/ScoreCategoriesSettings.ts
@@ -1,0 +1,11 @@
+import ScoreCategory from "@/lib/models/ScoreCategory";
+import ScoreCategorySettings from "@/lib/models/ScoreCategorySettings";
+
+interface ScoreCategoriesSettings {
+  [ScoreCategory.toxic]: ScoreCategorySettings;
+  [ScoreCategory.profane]: ScoreCategorySettings;
+  [ScoreCategory.threat]: ScoreCategorySettings;
+  [ScoreCategory.insult]: ScoreCategorySettings;
+}
+
+export default ScoreCategoriesSettings;

--- a/lib/models/ScoreCategory.ts
+++ b/lib/models/ScoreCategory.ts
@@ -1,0 +1,8 @@
+enum ScoreCategory {
+  toxic,
+  profane,
+  threat,
+  insult,
+}
+
+export default ScoreCategory;

--- a/lib/models/ScoreCategorySettings.ts
+++ b/lib/models/ScoreCategorySettings.ts
@@ -1,0 +1,6 @@
+interface ScoreCategorySetting {
+  enabled: boolean;
+  weight: number;
+}
+
+export default ScoreCategorySetting;

--- a/lib/models/SummaryScoreMode.ts
+++ b/lib/models/SummaryScoreMode.ts
@@ -1,0 +1,6 @@
+enum SummaryScoreMode {
+  highest,
+  weighted,
+}
+
+export default SummaryScoreMode;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "toxicity-bot",
       "version": "0.1.0",
       "dependencies": {
+        "@fortawesome/fontawesome-svg-core": "^6.4.0",
+        "@fortawesome/free-solid-svg-icons": "^6.4.0",
+        "@fortawesome/react-fontawesome": "^0.2.0",
         "@types/node": "18.15.10",
         "@types/react": "18.0.29",
         "@types/react-dom": "18.0.11",
@@ -87,6 +90,51 @@
       "integrity": "sha512-lxJ9R5ygVm8ZWgYdUweoq5ownDlJ4upvoWmO4eLxBYHdMo+vZ/Rx0EN6MbKWDJOSUGrqJy2Gt+Dyv/VKml0fjg==",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.4.0.tgz",
+      "integrity": "sha512-HNii132xfomg5QVZw0HwXXpN22s7VBHQBv9CeOu9tfJnhsWQNd2lmTNi8CSrnw5B+5YOmzu1UoPAyxaXsJ6RgQ==",
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.4.0.tgz",
+      "integrity": "sha512-Bertv8xOiVELz5raB2FlXDPKt+m94MQ3JgDfsVbrqNpLU9+UE2E18GKjLKw+d3XbeYPqg1pzyQKGsrzbw+pPaw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.4.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.4.0.tgz",
+      "integrity": "sha512-kutPeRGWm8V5dltFP1zGjQOEAzaLZj4StdQhWVZnfGFCvAPVvHh8qk5bRrU4KXnRRRNni5tKQI9PBAdI6MP8nQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.4.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/react-fontawesome": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.0.tgz",
+      "integrity": "sha512-uHg75Rb/XORTtVt7OS9WoK8uM276Ufi7gCzshVWkUJbHhh3svsUUeqXerrM96Wm7fRiDzfKRwSoahhMIkGAYHw==",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
+        "react": ">=16.3"
       }
     },
     "node_modules/@humanwhocodes/config-array": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^6.4.0",
+    "@fortawesome/free-solid-svg-icons": "^6.4.0",
+    "@fortawesome/react-fontawesome": "^0.2.0",
     "@types/node": "18.15.10",
     "@types/react": "18.0.29",
     "@types/react-dom": "18.0.11",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,8 +1,13 @@
 import "@/styles/globals.scss";
+import "@fortawesome/fontawesome-svg-core/styles.css";
 
 import { Inter } from "next/font/google";
 
+import { config } from "@fortawesome/fontawesome-svg-core";
+
 import type { AppProps } from "next/app";
+
+config.autoAddCss = false;
 
 // If loading a variable font, you don't need to specify the font weight
 const inter = Inter({ subsets: ["latin"] });

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,17 +2,32 @@ import Head from "next/head";
 import { useState } from "react";
 
 import { HeatMeter } from "@/lib/components/HeatMeter";
+import QuickSettings from "@/lib/components/QuickSettings";
 import PerspectiveScores from "@/lib/models/PerspectiveScores";
+import ScoreCategoriesSettings from "@/lib/models/ScoreCategoriesSettings";
+import ScoreCategory from "@/lib/models/ScoreCategory";
+import SummaryScoreMode from "@/lib/models/SummaryScoreMode";
 import styles from "@/styles/Home.module.scss";
 
 import ScoredSentenceList, { SentenceAndScore } from "../lib/components/ScoredSentenceList";
 
 export default function Home() {
+  const defaultScoreCategoriesSettings: ScoreCategoriesSettings = {
+    [ScoreCategory.toxic]: { enabled: true, weight: 0.5 },
+    [ScoreCategory.profane]: { enabled: true, weight: 0.5 },
+    [ScoreCategory.threat]: { enabled: true, weight: 0.5 },
+    [ScoreCategory.insult]: { enabled: true, weight: 0.5 },
+  };
+
   const [buttonEnabled, setButtonEnabled] = useState(false);
   const [scores, setScores] = useState<PerspectiveScores | null>(null);
   const [userInput, setUserInput] = useState("");
   const [sentencesAndScores, setSentencesAndScores] = useState<SentenceAndScore[]>([]);
   const [toxicityThreshold, setToxicityThreshold] = useState(40);
+  const [summaryScoreMode, setSummaryScoreMode] = useState(SummaryScoreMode.highest);
+  const [scoreCategoriesSettings, setScoreCategoriesSettings] = useState(
+    defaultScoreCategoriesSettings
+  );
 
   /**
    * Get scores from API
@@ -138,6 +153,19 @@ export default function Home() {
             </div>
           </form>
         </div>
+
+        <QuickSettings
+          summaryScoreMode={summaryScoreMode}
+          handleSummaryScoreModeChange={newSummaryScoreMode =>
+            setSummaryScoreMode(newSummaryScoreMode)
+          }
+          scoreCategoriesSettings={scoreCategoriesSettings}
+          handleScoreCategoriesSettingsChange={newScoreCategoriesSettings =>
+            setScoreCategoriesSettings(newScoreCategoriesSettings)
+          }
+          handleReset={() => setScoreCategoriesSettings(defaultScoreCategoriesSettings)}
+        />
+
         {/* #FIXME: Add state for percentage */}
         <div className={styles.heatmeter}>
           <HeatMeter percentage={getPercentage()} />

--- a/styles/Home.module.scss
+++ b/styles/Home.module.scss
@@ -14,6 +14,10 @@
   grid-area: scores;
 }
 
+.settings {
+  grid-area: settings;
+}
+
 .textBox {
   grid-area: box;
 }

--- a/styles/components/QuickSettings.module.scss
+++ b/styles/components/QuickSettings.module.scss
@@ -1,0 +1,31 @@
+.mainContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.toggleSliders {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-gap: 10px;
+}
+
+// #TODO: Use mixins for colors
+.toggleSlider {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  height: 100px;
+  border-radius: 5px;
+  background: rgb(226, 226, 226);
+  box-shadow: 0 5px 5px 0 rgba(0, 0, 0, 0.5);
+  transition: 0.1s ease-out;
+  cursor: pointer;
+
+  &--disabled {
+    color: gray;
+    box-shadow: none;
+  }
+}

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -2,3 +2,16 @@ a {
   color: inherit;
   text-decoration: none;
 }
+
+button {
+  font-family: "Inter";
+  cursor: pointer;
+}
+
+input[type="checkbox"] {
+  cursor: pointer;
+}
+
+input[type="range"] {
+  cursor: pointer;
+}


### PR DESCRIPTION
#8 
Add core functionality for quick settings. I’m still working on the CSS. I’m gonna open another pull for the styles, since the core features is more important rn.

All the other parts need to use the quick settings to calculate scores. We should keep the original scores as a state, and create another state that automatically recalculates our custom scores every time the settings or scores updates (use the `useEffect` hook).