### PR TITLE
Add automatic scoring

### DIFF
--- a/lib/models/SummaryScores.ts
+++ b/lib/models/SummaryScores.ts
@@ -1,0 +1,16 @@
+import ScoreCategory from "./ScoreCategory";
+
+interface SummaryScores {
+  main: {
+    score: number;
+    category?: ScoreCategory;
+  };
+  spans: {
+    begin: number;
+    end: number;
+    score: number;
+    category?: ScoreCategory;
+  }[];
+}
+
+export default SummaryScores;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,5 @@
 import Head from "next/head";
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import HeatMeter from "@/lib/components/HeatMeter";
 import QuickSettings from "@/lib/components/QuickSettings";
@@ -8,7 +8,10 @@ import PerspectiveScores from "@/lib/models/PerspectiveScores";
 import ScoreCategoriesSettings from "@/lib/models/ScoreCategoriesSettings";
 import ScoreCategory from "@/lib/models/ScoreCategory";
 import SummaryScoreMode from "@/lib/models/SummaryScoreMode";
+import SummaryScores from "@/lib/models/SummaryScores";
 import styles from "@/styles/Home.module.scss";
+
+const AUTO_FETCH_INTERVAL = 500;
 
 export default function Home() {
   const defaultScoreCategoriesSettings: ScoreCategoriesSettings = {
@@ -18,20 +21,23 @@ export default function Home() {
     [ScoreCategory.insult]: { enabled: true, weight: 0.5 },
   };
 
-  const [buttonEnabled, setButtonEnabled] = useState(false);
-  const [scores, setScores] = useState<PerspectiveScores | null>(null);
   const [userInput, setUserInput] = useState("");
-  const [sentencesAndScores, setSentencesAndScores] = useState<SentenceAndScore[]>([]);
-  const [toxicityThreshold, setToxicityThreshold] = useState(40);
+  const [textFromLastUpdate, setTextFromLastUpdate] = useState("");
+
+  // Settings
   const [summaryScoreMode, setSummaryScoreMode] = useState(SummaryScoreMode.highest);
   const [scoreCategoriesSettings, setScoreCategoriesSettings] = useState(
     defaultScoreCategoriesSettings
   );
+  const [toxicityThreshold, setToxicityThreshold] = useState(40);
 
-  /**
-   * Get scores from API
-   */
-  const updateScore = async () => {
+  // Scores
+  const [scores, setScores] = useState<PerspectiveScores | null>(null);
+  const [adjustedScores, setAdjustedScores] = useState<SummaryScores | null>(null);
+  const [sentencesAndScores, setSentencesAndScores] = useState<SentenceAndScore[]>([]);
+
+  /** Get scores from API. */
+  const updateScore = useCallback(async () => {
     const response = await fetch("/api/score", {
       method: "POST",
       headers: {
@@ -47,72 +53,122 @@ export default function Home() {
     }
     const scores = data as PerspectiveScores;
     setScores(scores);
-    formatForSentencesAnalysis(scores);
-    formatForSentencesAnalysis(scores);
-  };
+  }, [userInput]);
 
-  function formatForSentencesAnalysis(scores: PerspectiveScores): any {
-    let temp = [];
-    for (let i = 0; i < scores.spans[ScoreCategory.toxic].length; i++) {
-      let toxicity = Math.trunc(
-        Math.max(
-          scores.spans[ScoreCategory.toxic][i].score,
-          scores.spans[ScoreCategory.profane][i].score,
-          scores.spans[ScoreCategory.insult][i].score,
-          scores.spans[ScoreCategory.threat][i].score
-        ) * 100
-      );
-      if (toxicity >= toxicityThreshold) {
-        temp.push({
-          text: userInput
-            .substring(
-              scores.spans[ScoreCategory.toxic][i].begin,
-              scores.spans[ScoreCategory.toxic][i].end
-            )
-            .trim(),
-          percentage: toxicity,
-          suggestion: "Kimi",
-        });
+  const formatForSentencesAnalysis = useCallback(
+    (scores: PerspectiveScores) => {
+      let temp = [];
+      for (let i = 0; i < scores.spans[ScoreCategory.toxic].length; i++) {
+        let toxicity = Math.trunc(
+          Math.max(
+            scores.spans[ScoreCategory.toxic][i].score,
+            scores.spans[ScoreCategory.profane][i].score,
+            scores.spans[ScoreCategory.insult][i].score,
+            scores.spans[ScoreCategory.threat][i].score
+          ) * 100
+        );
+        if (toxicity >= toxicityThreshold) {
+          temp.push({
+            text: textFromLastUpdate
+              .substring(
+                scores.spans[ScoreCategory.toxic][i].begin,
+                scores.spans[ScoreCategory.toxic][i].end
+              )
+              .trim(),
+            percentage: toxicity,
+            suggestion: "Kimi",
+          });
+        }
       }
-    }
-    // get rid of duplicate texts
-    var out = temp.reduce(function (p: any, c: any) {
-      if (
-        !p.some(function (el: any) {
-          return el.text === c.text;
-        })
-      )
-        p.push(c);
-      return p;
-    }, []);
-    // sort by percentage
-    out.sort(function (left: SentenceAndScore, right: SentenceAndScore): number {
-      if (left.percentage < right.percentage) {
-        return 1;
-      }
-      if (left.percentage > right.percentage) {
-        return -1;
-      }
-      return 0;
-    });
-    setSentencesAndScores(out);
-  }
+      // get rid of duplicate texts
+      var out = temp.reduce(function (p: any, c: any) {
+        if (
+          !p.some(function (el: any) {
+            return el.text === c.text;
+          })
+        )
+          p.push(c);
+        return p;
+      }, []);
+      // sort by percentage
+      out.sort(function (left: SentenceAndScore, right: SentenceAndScore): number {
+        if (left.percentage < right.percentage) {
+          return 1;
+        }
+        if (left.percentage > right.percentage) {
+          return -1;
+        }
+        return 0;
+      });
+      setSentencesAndScores(out);
+    },
+    [toxicityThreshold, textFromLastUpdate]
+  );
 
   function editInputText(original: string, suggestion: string) {
-    console.log(original);
-    console.log(suggestion);
     let temp: string = userInput.replace(original, suggestion);
     setUserInput(temp);
   }
 
-  // #FIXME: Replace with stateful operations
-  const getPercentage = () => {
+  /** Automatically fetch the score every second if the text changes. */
+  useEffect(() => {
+    const interval = setInterval(() => {
+      if (userInput === "") {
+        setScores(null);
+        setTextFromLastUpdate("");
+        return;
+      }
+      if (userInput === textFromLastUpdate) return;
+      updateScore();
+      setTextFromLastUpdate(userInput);
+    }, AUTO_FETCH_INTERVAL);
+    return () => clearInterval(interval);
+  });
+
+  /** Calculate the adjusted scores */
+  useEffect(() => {
     if (scores === null) {
-      return null;
+      setAdjustedScores(null);
+      return;
     }
-    const [_, score] = Object.entries(scores.summary).reduce((a, b) => (a[1] > b[1] ? a : b));
-    return score;
-  };
+    // #FIXME: Check settings
+
+    // Calculate the main score
+    const [mainCategory, mainScore]: [ScoreCategory, number] = Object.entries(scores.summary)
+      .map(([category, score]: [string, number]): [ScoreCategory, number] => [
+        ScoreCategory[category as keyof typeof ScoreCategory],
+        score,
+      ])
+      .reduce((prev, curr) => (prev[1] > curr[1] ? prev : curr));
+
+    // Calculate scores for each span
+    const numSpans = scores.spans[ScoreCategory.toxic].length;
+
+    // Initialize an empty array of size numSpans
+    const spanScores: {
+      begin: number;
+      end: number;
+      score: number;
+      category?: ScoreCategory;
+    }[] = Array(numSpans).fill(null);
+
+    // #FIXME: Fill in the array with the scores
+
+    setAdjustedScores({
+      main: {
+        category: mainCategory,
+        score: mainScore,
+      },
+      spans: spanScores,
+    });
+  }, [scores, summaryScoreMode, scoreCategoriesSettings]);
+
+  // #FIXME: Use adjustedScores instead of scores
+  /** Recalculate sentence scores automatically. */
+  useEffect(() => {
+    if (scores === null) return;
+    formatForSentencesAnalysis(scores);
+  }, [formatForSentencesAnalysis, scores, toxicityThreshold]);
 
   return (
     <>
@@ -134,30 +190,16 @@ export default function Home() {
           <textarea
             className={styles["inputForm__textarea"]}
             maxLength={15000}
-            onChange={(e) => {
-              e.preventDefault();
-              setUserInput(e.target.value);
-              setButtonEnabled(e.target.value !== "");
+            onInput={(e) => {
+              setUserInput(e.currentTarget.value);
             }}
             value={userInput}
           />
-          <div>
-            <button
-              className={styles.submitButton}
-              onClick={(e) => {
-                e.preventDefault();
-                updateScore();
-              }}
-              disabled={!buttonEnabled}
-            >
-              Submit
-            </button>
-          </div>
         </form>
 
         {/* #FIXME: Add state for percentage */}
         <div className={styles.heatmeter}>
-          <HeatMeter percentage={getPercentage()} />
+          <HeatMeter percentage={adjustedScores?.main.score ?? null} />
         </div>
 
         <div className={styles.scores}>


### PR DESCRIPTION
- Automatically calculate scores every half a second if the text has changed
- `textFromLastUpdate` stores the text from the last time the API was fetched in order to compare if the text has changed
- The main percentage is now stored in `adjustedScores.main.score`
  - `adjustedScores` is automatically calculated whenever the score or settings change
    - #FIXME: Need to merge Kimi’s calculations
  - There’s also a `adjustedScores.main.category` that stores the category with the highest score
- Replace `onChange` with `onInput` to get immediate feedback instead of waiting for the `textarea` to lose focus
- Add a `SummaryScores` interface for storing the post-adjustment scores
- There’s some duplicate code copied from `formatForSentencesAnalysis()` b/c I was waiting for changes in #40.